### PR TITLE
Sudo if need

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ And if `monit:status` returns the following output:
 Then launching the `monit:start` task will only handle the `production-puma`
 and `production-redis` processes.
 
+## Configuring sudo
+
+If you don't want monit to be executed with sudo, add this to your `config/deploy.rb`:
+
+```ruby
+set :execute_monit_without_sudo, true
+```
+
 # TODO
 
 * Add tasks to manage the monit service itself

--- a/lib/capistrano/tasks/monit.rake
+++ b/lib/capistrano/tasks/monit.rake
@@ -3,7 +3,7 @@ namespace :monit do
   desc 'Monit status'
   task :status do
     on roles :app do
-      puts capture :sudo, :monit, :status
+      puts sudo_if_needed :capture, :monit, :status
     end
   end
 
@@ -24,18 +24,26 @@ namespace :monit do
 
   def monit_do(*args)
     on roles :app do
-      execute :sudo, :monit, *args
+      sudo_if_needed :execute, :monit, *args
     end
   end
 
   def all_processes_do(cmd)
     on roles :app do
-      output = capture :sudo, :monit, :status
+      output = sudo_if_needed :capture, :monit, :status
       processes = output.lines.grep(/^Process '/).grep(/#{fetch(:application)}/)
       processes.each do |process|
         process_name = process.split(/\s+/).last.delete "'"
         monit_do cmd, process_name
       end
+    end
+  end
+
+  def sudo_if_needed(action, *args)
+    if fetch(:execute_monit_without_sudo)
+      send action, *args
+    else
+      send action, :sudo, *args
     end
   end
 end


### PR DESCRIPTION
Needed this to use monit without the sudo prefix. Found the implementation [here](https://github.com/seuros/capistrano-puma/blob/master/lib/capistrano/tasks/monit.rake). 
